### PR TITLE
I ran into incompatibility of the mongo docker image when running on …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Giftcard application is split into four parts, using four sub-packages of `i
 
 To build the demo app, simply run the provided [Maven wrapper](https://www.baeldung.com/maven-wrapper):
 
-```
+```shell
 ./mvnw clean package
 ```
 
@@ -54,7 +54,7 @@ Note that the Giftcard app expects JDK 17 to be used.
 
 The simplest way to run the app is by using the Spring-boot maven plugin:
 
-```
+```shell
 ./mvnw spring-boot:run
 ```
 However, if you have copied the jar file `giftcard-demo-1.0.jar` from the Maven `target` directory to some other location, you can also start it with:
@@ -121,5 +121,16 @@ Axon Synapse has its own ui, available at `localhost:8081` when using the docker
 
 ## Deno
 
-run with `deno run --allow-net --allow-read --import-map ./import_map.json server.ts` in the deno folder. You need to have [Deno](https://docs.deno.com/runtime/manual/getting_started/installation) installed.
+You need to have [Deno](https://docs.deno.com/runtime/manual/getting_started/installation) installed. If you are on a mac, you can run:
+```shell
+brew install deno
+```
 
+After that, you can run the deno app with: 
+```shell
+cd deno
+deno run --allow-net --allow-read --import-map ./import_map.json server.ts
+```
+
+## Potential Gotchas
+- [Mongo issues on Apple Silicon](docker/apple_silicon_gotchas.md)

--- a/docker/Dockerfile_mongo
+++ b/docker/Dockerfile_mongo
@@ -1,0 +1,7 @@
+#Dockerfile
+
+FROM --platform=linux/arm64/v8 mongo:latest
+
+EXPOSE 27017
+
+CMD ["mongod"]

--- a/docker/apple_silicon_gotchas.md
+++ b/docker/apple_silicon_gotchas.md
@@ -1,0 +1,39 @@
+# Apple Silicon
+
+If you are running on Apple Silicon Mac, you will run into an issue with the `bitnami/mongodb:6.0.10` in
+[docker-compose.yml](docker-compose.yml): it does not support arm64.
+
+To work around this, you will need to build your own:
+
+1. Build an arm64 image of MongoDB:
+    ```shell
+    docker buildx create --name mybuilder
+    docker buildx use mybuilder
+    docker buildx build --platform linux/arm64 --load -t my-mongo-arm64:latest -f Dockerfile_mongo .
+    ```
+2. Replace the mongo section in [docker-compose.yml](docker-compose.yml) with this:
+    ```yaml
+      mongodb:
+        image: my-mongo-arm64:latest
+        command: [ "mongod", "--bind_ip_all", "--replSet", "rs0" ]
+        ports:
+          - "27017:27017"
+        environment:
+          - MONGODB_REPLICA_SET_MODE=primary
+          - ALLOW_EMPTY_PASSWORD=yes
+        networks:
+          - giftcard-demo-network
+    ```
+   Compared to original, it uses the image you just built and adds `command` line that makes mongo run in as a member
+   of a replica set as opposed to standalone server: some operation seeks to use a transaction which needs a replica set
+   configured in [mongo-init.js](mongo-init.js).
+3. Start Axon, Synapse and MongoDB with:
+    ```shell
+    docker-compose -f docker-compose.yml up -d --build
+    ```
+4. Follow the rest of instructions in [README.md](../README.md) to build and run the GiftCard and the Deno apps.
+
+You can stop docker by running:
+```shell
+docker-compose -f docker-compose.yml down
+```

--- a/docker/mongo-init.js
+++ b/docker/mongo-init.js
@@ -1,0 +1,8 @@
+rs.initiate(
+    {
+        _id : "rs0",
+        members: [
+            { _id : 0, host : "localhost:27017" }
+        ]
+    }
+)


### PR DESCRIPTION
…an Apple Silicon: it won't start up as the image does not support arm64. This PR provides a way to overcome it.

Changes:
- added instructions to README.md to deal with mongo gotchas (a link in the new section on the bottom, "Potential Gotchas")
- added docker/apple_silicon_gotchas.md containing instructions on how to solve it
- docker/Dockerfile_mongo, defining an image based on mongo:latest
 - docker/mongo-init.js, configuring mongo to run as a member of a replica set (otherwise the giftcard app fails to connect to Mongo standalone server, which is how the unadorned mongo:latest runs)